### PR TITLE
Split policy actions into objects

### DIFF
--- a/pkg/daemon/action.go
+++ b/pkg/daemon/action.go
@@ -1,68 +1,66 @@
 package daemon
 
 import (
-	"fmt"
-
 	"github.com/JAORMX/selinuxd/pkg/semodule"
 	"github.com/JAORMX/selinuxd/pkg/utils"
 )
 
+type policyAction interface {
+	String() string
+	do(modulePath string, sh semodule.SEModuleHandler) (string, error)
+}
+
 // Defines an action to be taken on a policy file on the specified path
-type policyAction struct {
-	path      string
-	operation policyOp
+type policyInstall struct {
+	path string
 }
 
-// defines the operation that an action will take on the file
-type policyOp int16
-
-const (
-	install policyOp = iota
-	remove  policyOp = iota
-)
-
-func (po policyOp) String() string {
-	switch po {
-	case install:
-		return "install"
-	case remove:
-		return "remove"
-	default:
-		return "unknown"
-	}
+func NewInstallAction(path string) policyAction {
+	return &policyInstall{path}
 }
 
-func (pa policyAction) do(modulePath string, sh semodule.SEModuleHandler) (string, error) {
-	var policyArg string
-	var err error
+func (pi *policyInstall) String() string {
+	return "install - " + pi.path
+}
 
-	switch pa.operation {
-	case install:
-		policyPath, err := utils.GetSafePath(modulePath, pa.path)
-		if err != nil {
-			return "", err
-		}
-		err = sh.Install(policyPath)
-	case remove:
-		baseFile, err := utils.GetCleanBase(pa.path)
-		if err != nil {
-			return "", err
-		}
-		policyArg = utils.GetFileWithoutExtension(baseFile)
-
-		if !pa.moduleInstalled(sh, policyArg) {
-			return "No action needed; Module is not in the system", nil
-		}
-
-		err = sh.Remove(policyArg)
-	default:
-		return "", fmt.Errorf("Unkown operation for policy %s. This shouldn't happen", pa.path)
+func (pi *policyInstall) do(modulePath string, sh semodule.SEModuleHandler) (string, error) {
+	policyPath, err := utils.GetSafePath(modulePath, pi.path)
+	if err != nil {
+		return "", err
 	}
-
+	err = sh.Install(policyPath)
 	return "", err
 }
 
-func (pa policyAction) moduleInstalled(sh semodule.SEModuleHandler, policy string) bool {
+type policyRemove struct {
+	path string
+}
+
+func NewRemoveAction(path string) policyAction {
+	return &policyRemove{path}
+}
+
+func (pi *policyRemove) String() string {
+	return "remove - " + pi.path
+}
+
+func (pi *policyRemove) do(modulePath string, sh semodule.SEModuleHandler) (string, error) {
+	var policyArg string
+	baseFile, err := utils.GetCleanBase(pi.path)
+	if err != nil {
+		return "", err
+	}
+	policyArg = utils.GetFileWithoutExtension(baseFile)
+
+	if !pi.moduleInstalled(sh, policyArg) {
+		return "No action needed; Module is not in the system", nil
+	}
+
+	err = sh.Remove(policyArg)
+	return "", err
+}
+
+func (pi *policyRemove) moduleInstalled(sh semodule.SEModuleHandler, policy string) bool {
 	currentModules, err := sh.List()
 	if err != nil {
 		return false


### PR DESCRIPTION
This defines an interface to do actions generically, and instead splits
the install and remove actions into their own objects. This keeps the
functions small and easier to understand.