### PR TITLE
Add github actions

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -1,0 +1,22 @@
+name: build-and-test
+
+on: [push, pull_request]
+
+jobs:
+  build-selinuxd:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        centos: ["8"]
+    container:
+      image: centos:${{ matrix.centos }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: remove media repo
+        run: rm -f /etc/yum.repos.d/CentOS-Media.repo
+      - name: install packages
+        run: yum -y --enablerepo=\* install golang make libsemanage-devel
+      - name: build selinuxd
+        run: |
+          make
+          make test


### PR DESCRIPTION
Adds a simple GH action that just runs make and make test. Uses an Ubuntu runner
because GH actions don't support fedora/centos. To work around that, the action
uses a centos:8 container. This means we can't test the policies themselves as
we'd need a SELinux-enabled container for that -- we can use a self-hosted
runner if we so desire later, though.