### PR TITLE
Use static libraries

### DIFF
--- a/pkg/semodule/semanage/semanage.go
+++ b/pkg/semodule/semanage/semanage.go
@@ -2,7 +2,7 @@ package semanage
 
 /*
 #cgo CFLAGS: -I/usr/include/semanage
-#cgo LDFLAGS: -L/usr/lib64 -lsemanage -lsepol
+#cgo LDFLAGS: -L/usr/lib64 -laudit /usr/lib64/libsemanage.a /usr/lib64/libsepol.a /usr/lib64/libselinux.a /usr/lib64/libbz2.a
 #include <semanage.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
audit-libs are still linked to dynamically because Fedora doesn't ship audit-libs-static anymore