### PR TITLE
Fix github actions

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -12,10 +12,8 @@ jobs:
       image: centos:${{ matrix.centos }}
     steps:
       - uses: actions/checkout@v2
-      - name: remove media repo
-        run: rm -f /etc/yum.repos.d/CentOS-Media.repo
       - name: install packages
-        run: yum -y --enablerepo=\* install golang make libsemanage-devel
+        run: yum -y --enablerepo=powertools install golang make libsemanage-devel
       - name: build selinuxd
         run: |
           make


### PR DESCRIPTION
By selectively enabling the only repository we need in addition to the
default set in order to install libsemanage-devel.

This also means the CI is faster as we have to fetch less metadata.