### PR TITLE
Provide a UNIX socket that allows listing policies

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -10,7 +10,11 @@ import (
 	"gopkg.in/fsnotify.v1"
 )
 
-func Daemon(modulePath string, sh semodule.SEModuleHandler, done chan bool, logger logr.Logger) {
+type SelinuxdOptions struct {
+	StatusServerConfig
+}
+
+func Daemon(options *SelinuxdOptions, modulePath string, sh semodule.SEModuleHandler, done chan bool, logger logr.Logger) {
 	policyops := make(chan policyAction)
 
 	logger.Info("Started daemon")
@@ -25,6 +29,8 @@ func Daemon(modulePath string, sh semodule.SEModuleHandler, done chan bool, logg
 	go watchFiles(watcher, policyops, logger)
 
 	go installPolicies(modulePath, sh, policyops, logger)
+
+	go serveState(options.StatusServerConfig, sh, logger)
 
 	// NOTE(jaosorior): We do this before adding the path to the notification
 	// watcher so all the policies are installed already when we start watching

--- a/pkg/daemon/status_server.go
+++ b/pkg/daemon/status_server.go
@@ -1,0 +1,82 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/JAORMX/selinuxd/pkg/semodule"
+	"github.com/go-logr/logr"
+	"net"
+	"net/http"
+	"os"
+)
+
+const unixSockAddr = "/var/run/selinuxd.sock"
+const unixSockMode = 0660
+
+type StatusServerConfig struct {
+	Path string
+	Uid int
+	Gid int
+}
+
+func createSocket(path string, uid, gid int) (net.Listener, error) {
+	if err := os.RemoveAll(path); err != nil {
+		return nil, fmt.Errorf("cannot remove old socket: %w", err)
+	}
+
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("listen error: %w", err)
+	}
+
+	err = os.Chown(path, uid, gid)
+	if err != nil {
+		return nil, fmt.Errorf("chown error: %w", err)
+	}
+
+	err = os.Chmod(path, unixSockMode)
+	if err != nil {
+		return nil, fmt.Errorf("chmod error: %w", err)
+	}
+
+	return listener, nil
+}
+
+func serveState(config StatusServerConfig, sh semodule.SEModuleHandler, logger logr.Logger) {
+	slog := logger.WithName("state-server")
+
+	if config.Path == "" {
+		config.Path = unixSockAddr
+	}
+
+	slog.Info("Serving status", "path", config.Path, "uid", config.Uid, "gid", config.Gid)
+
+	listener, err := createSocket(config.Path, config.Uid, config.Gid)
+	if err != nil {
+		slog.Error(err, "error setting up socket")
+		// TODO: jhrozek: signal exit
+		return
+	}
+
+	mux := http.NewServeMux()
+	policiesHandler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "" && r.Method != "GET" {
+			http.Error(w, "Only GET is allowed", http.StatusBadRequest)
+			return
+		}
+
+		modules, err := sh.List()
+		if err != nil {
+			http.Error(w, "Cannot list modules", http.StatusInternalServerError)
+			return
+		}
+
+		json.NewEncoder(w).Encode(modules)
+	}
+
+	mux.HandleFunc("/policies/", policiesHandler)
+	server := &http.Server{
+		Handler: mux,
+	}
+    server.Serve(listener)
+}


### PR DESCRIPTION
adds a new goroutine to the deamon that creates a socket that the deamon
listens on. There is an HTTP server listening on the socket that handles
a single path /policies and only handles HTTP GET requests. The answer
to that request is a JSON list of all the loaded policies as string,
similar to what a call to semanage -l would produce.

There is so far no access control on the socket except for the UNIX
permissions of the socket which are settable through command line
parameters.