### PR TITLE
Golangci lint: Introduce check and fix warnings

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,19 @@
+name: verify
+
+on: [push, pull_request]
+
+jobs:
+  build-selinuxd:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        centos: ["8"]
+    container:
+      image: centos:${{ matrix.centos }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: install packages
+        run: yum -y --enablerepo=powertools install golang make libsemanage-devel diffutils
+      - name: run verify
+        run: |
+          make verify

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,152 @@
+---
+run:
+  build-tags:
+    - netgo
+    - e2e
+  concurrency: 6
+  deadline: 5m
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - gci
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    # TODO(jaosorior): Re-Add later
+    #- godot
+    - godox
+    - goerr113
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - golint
+    - gomnd
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - maligned
+    - misspell
+    - nakedret
+    - nestif
+    - noctx
+    - nolintlint
+    - prealloc
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    - wrapcheck
+    # - exhaustivestruct
+    # - funlen
+    # - gochecknoglobals
+    # - nlreturn
+    # - scopelint
+    # - testpackage
+    # - wsl
+linters-settings:
+  gci:
+    local-prefixes: sigs.k8s.io/security-profiles-operator
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+  godox:
+    keywords:
+      - BUG
+      - FIXME
+      - HACK
+  gocritic:
+    enabled-checks:
+      # Diagnostic
+      - appendAssign
+      - argOrder
+      - badCond
+      - caseOrder
+      - codegenComment
+      - commentedOutCode
+      - deprecatedComment
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - dupSubExpr
+      - exitAfterDefer
+      - flagDeref
+      - flagName
+      - nilValReturn
+      - offBy1
+      - sloppyReassign
+      - weakCond
+      - octalLiteral
+
+      # Performance
+      - appendCombine
+      - equalFold
+      - hugeParam
+      - indexAlloc
+      - rangeExprCopy
+      - rangeValCopy
+
+      # Style
+      - assignOp
+      - boolExprSimplify
+      - captLocal
+      - commentFormatting
+      - commentedOutImport
+      - defaultCaseOrder
+      - docStub
+      - elseif
+      - emptyFallthrough
+      - emptyStringTest
+      - hexLiteral
+      - ifElseChain
+      - methodExprCall
+      - regexpMust
+      - singleCaseSwitch
+      - sloppyLen
+      - stringXbytes
+      - switchTrue
+      - typeAssertChain
+      - typeSwitchVar
+      - underef
+      - unlabelStmt
+      - unlambda
+      - unslice
+      - valSwap
+      - wrapperFunc
+      - yodaStyleExpr
+
+      # Opinionated
+      - builtinShadow
+      - importShadow
+      - initClause
+      - nestingReduce
+      - paramTypeCombine
+      - ptrToRefParam
+      - typeUnparen
+      - unnamedResult
+      - unnecessaryBlock

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,9 +19,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
-
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
@@ -51,6 +50,7 @@ func Execute() {
 	}
 }
 
+// nolint:gochecknoinits
 func init() {
 	cobra.OnInitialize(initConfig)
 

--- a/pkg/daemon/action.go
+++ b/pkg/daemon/action.go
@@ -1,13 +1,15 @@
 package daemon
 
 import (
+	"fmt"
+
 	"github.com/JAORMX/selinuxd/pkg/semodule"
 	"github.com/JAORMX/selinuxd/pkg/utils"
 )
 
 type policyAction interface {
 	String() string
-	do(modulePath string, sh semodule.SEModuleHandler) (string, error)
+	do(modulePath string, sh semodule.Handler) (string, error)
 }
 
 // Defines an action to be taken on a policy file on the specified path
@@ -15,7 +17,8 @@ type policyInstall struct {
 	path string
 }
 
-func NewInstallAction(path string) policyAction {
+// newInstallAction will execute the "install" action for a policy.
+func newInstallAction(path string) policyAction {
 	return &policyInstall{path}
 }
 
@@ -23,20 +26,23 @@ func (pi *policyInstall) String() string {
 	return "install - " + pi.path
 }
 
-func (pi *policyInstall) do(modulePath string, sh semodule.SEModuleHandler) (string, error) {
+func (pi *policyInstall) do(modulePath string, sh semodule.Handler) (string, error) {
 	policyPath, err := utils.GetSafePath(modulePath, pi.path)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed getting a safe path for policy: %w", err)
 	}
-	err = sh.Install(policyPath)
-	return "", err
+	if err := sh.Install(policyPath); err != nil {
+		return "", fmt.Errorf("failed executing install action: %w", err)
+	}
+	return "", nil
 }
 
 type policyRemove struct {
 	path string
 }
 
-func NewRemoveAction(path string) policyAction {
+// newInstallAction will execute the "remove" action for a policy.
+func newRemoveAction(path string) policyAction {
 	return &policyRemove{path}
 }
 
@@ -44,11 +50,11 @@ func (pi *policyRemove) String() string {
 	return "remove - " + pi.path
 }
 
-func (pi *policyRemove) do(modulePath string, sh semodule.SEModuleHandler) (string, error) {
+func (pi *policyRemove) do(modulePath string, sh semodule.Handler) (string, error) {
 	var policyArg string
 	baseFile, err := utils.GetCleanBase(pi.path)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed getting clean base name for policy: %w", err)
 	}
 	policyArg = utils.GetFileWithoutExtension(baseFile)
 
@@ -56,11 +62,13 @@ func (pi *policyRemove) do(modulePath string, sh semodule.SEModuleHandler) (stri
 		return "No action needed; Module is not in the system", nil
 	}
 
-	err = sh.Remove(policyArg)
-	return "", err
+	if err := sh.Remove(policyArg); err != nil {
+		return "", fmt.Errorf("failed executing remove action: %w", err)
+	}
+	return "", nil
 }
 
-func (pi *policyRemove) moduleInstalled(sh semodule.SEModuleHandler, policy string) bool {
+func (pi *policyRemove) moduleInstalled(sh semodule.Handler, policy string) bool {
 	currentModules, err := sh.List()
 	if err != nil {
 		return false

--- a/pkg/semodule/interface.go
+++ b/pkg/semodule/interface.go
@@ -1,8 +1,8 @@
 package semodule
 
-// SEModuleHandler implements an interface to interact
+// Handler implements an interface to interact
 // with SELinux modules.
-type SEModuleHandler interface {
+type Handler interface {
 	Install(string) error
 	List() ([]string, error)
 	Remove(string) error

--- a/pkg/semodule/test/testhandler.go
+++ b/pkg/semodule/test/testhandler.go
@@ -9,15 +9,19 @@ type SEModuleTestHandler struct {
 	modules []string
 }
 
-// Ensure that the test handler implements the SEModuleHandler interface
-var _ semodule.SEModuleHandler = &SEModuleTestHandler{}
+// Ensure that the test handler implements the Handler interface
+var _ semodule.Handler = &SEModuleTestHandler{}
 
 func NewSEModuleTestHandler() *SEModuleTestHandler {
 	return &SEModuleTestHandler{}
 }
 
 func (smt *SEModuleTestHandler) Install(modulePath string) error {
-	baseFile, _ := utils.GetCleanBase(modulePath)
+	baseFile, err := utils.GetCleanBase(modulePath)
+	if err != nil {
+		// nolint:wrapcheck
+		return err
+	}
 	module := utils.GetFileWithoutExtension(baseFile)
 	// Only install module if it's not already there.
 	if smt.IsModuleInstalled(module) {
@@ -42,6 +46,7 @@ func (smt *SEModuleTestHandler) List() ([]string, error) {
 	// Return a copy
 	return append([]string(nil), smt.modules...), nil
 }
+
 func (smt *SEModuleTestHandler) Remove(modToRemove string) error {
 	idToRemove := -1
 	for id, mod := range smt.modules {
@@ -53,6 +58,7 @@ func (smt *SEModuleTestHandler) Remove(modToRemove string) error {
 	smt.modules = append(smt.modules[:idToRemove], smt.modules[idToRemove+1:]...)
 	return nil
 }
+
 func (smt *SEModuleTestHandler) Close() error {
 	return nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,12 +1,19 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 )
 
+var ErrInvalidPath = errors.New("invalid path")
+
+func NewErrInvalidPath(path string) error {
+	return fmt.Errorf("%w: %s", ErrInvalidPath, path)
+}
+
 func GetFileWithoutExtension(filename string) string {
-	var extension = filepath.Ext(filename)
+	extension := filepath.Ext(filename)
 	return filename[0 : len(filename)-len(extension)]
 }
 
@@ -14,7 +21,7 @@ func GetCleanBase(path string) (string, error) {
 	// NOTE: don't trust the path even if it came from fsnotify
 	cleanPath := filepath.Clean(path)
 	if cleanPath == "" {
-		return "", fmt.Errorf("Invalid path: %s", path)
+		return "", NewErrInvalidPath(path)
 	}
 
 	// NOTE: Still not trusting that path. Let's just use the base


### PR DESCRIPTION
This introduces the `verify` target to the Makefile as well as a GH action that will run it.

It also fixes the warnings presented by the tool.