### PR TITLE
Implement oneshot command

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,0 +1,39 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+)
+
+const defaultModulePath = "/etc/selinux.d"
+
+func getLogger() (logr.Logger, error) {
+	logger, err := zap.NewProduction()
+	if err != nil {
+		return nil, fmt.Errorf("error creating logger: %w", err)
+	}
+	logIf := zapr.NewLogger(logger)
+	// NOTE(jaosorior): While this may return errors, they're mostly
+	// harmless and handling them is more work than its worth
+	// nolint:errcheck
+	defer logger.Sync() // flushes buffer, if any
+	return logIf, nil
+}

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -23,10 +23,7 @@ import (
 
 	"github.com/JAORMX/selinuxd/pkg/daemon"
 	"github.com/JAORMX/selinuxd/pkg/semodule/semanage"
-	"github.com/go-logr/logr"
-	"github.com/go-logr/zapr"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 // daemonCmd represents the daemon command
@@ -76,21 +73,7 @@ func parseFlags(rootCmd *cobra.Command) (*daemon.SelinuxdOptions, error) {
 	return &config, nil
 }
 
-func getLogger() (logr.Logger, error) {
-	logger, err := zap.NewProduction()
-	if err != nil {
-		return nil, fmt.Errorf("error creating logger: %w", err)
-	}
-	logIf := zapr.NewLogger(logger)
-	// NOTE(jaosorior): While this may return errors, they're mostly
-	// harmless and handling them is more work than its worth
-	// nolint:errcheck
-	defer logger.Sync() // flushes buffer, if any
-	return logIf, nil
-}
-
 func daemonCmdFunc(rootCmd *cobra.Command, _ []string) {
-	const modulePath = "/etc/selinux.d"
 	logger, err := getLogger()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s", err)
@@ -113,7 +96,7 @@ func daemonCmdFunc(rootCmd *cobra.Command, _ []string) {
 	}
 	defer sh.Close()
 
-	go daemon.Daemon(options, modulePath, sh, done, logger)
+	go daemon.Daemon(options, defaultModulePath, sh, done, logger)
 
 	<-exitSignal
 	logger.Info("Exit signal received")

--- a/cmd/oneshot.go
+++ b/cmd/oneshot.go
@@ -1,0 +1,68 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/JAORMX/selinuxd/pkg/daemon"
+	"github.com/JAORMX/selinuxd/pkg/semodule/semanage"
+	"github.com/spf13/cobra"
+)
+
+// oneshotCmd represents the oneshot command
+var oneshotCmd = &cobra.Command{
+	Use:   "oneshot",
+	Short: "install SELinux policies in the designated directory",
+	Long:  `This does a one-shot installation of SELinux policies.`,
+	Run:   oneshotCmdFunc,
+}
+
+// nolint:gochecknoinits
+func init() {
+	rootCmd.AddCommand(oneshotCmd)
+}
+
+func oneshotCmdFunc(rootCmd *cobra.Command, _ []string) {
+	logger, err := getLogger()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s", err)
+		syscall.Exit(1)
+	}
+
+	sh, err := semanage.NewSemanageHandler(logger)
+	if err != nil {
+		logger.Error(err, "Creating semanage handler")
+	}
+	defer sh.Close()
+
+	policyops := make(chan daemon.PolicyAction)
+
+	logger.Info("Running oneshot command")
+
+	go func() {
+		if err := daemon.InstallPoliciesInDir(defaultModulePath, policyops); err != nil {
+			logger.Error(err, "Installing policies in module directory")
+		}
+		close(policyops)
+	}()
+
+	daemon.InstallPolicies(defaultModulePath, sh, policyops, logger)
+
+	logger.Info("Done installing policies in directory")
+}

--- a/pkg/daemon/action.go
+++ b/pkg/daemon/action.go
@@ -7,7 +7,7 @@ import (
 	"github.com/JAORMX/selinuxd/pkg/utils"
 )
 
-type policyAction interface {
+type PolicyAction interface {
 	String() string
 	do(modulePath string, sh semodule.Handler) (string, error)
 }
@@ -18,7 +18,7 @@ type policyInstall struct {
 }
 
 // newInstallAction will execute the "install" action for a policy.
-func newInstallAction(path string) policyAction {
+func newInstallAction(path string) PolicyAction {
 	return &policyInstall{path}
 }
 
@@ -42,7 +42,7 @@ type policyRemove struct {
 }
 
 // newInstallAction will execute the "remove" action for a policy.
-func newRemoveAction(path string) policyAction {
+func newRemoveAction(path string) PolicyAction {
 	return &policyRemove{path}
 }
 


### PR DESCRIPTION
This allows us to do a oneshot pass at installing policies set up in the
/etc/selinux.d directory.

This will be useful for installing a bootstrap SELinux policy from an
initContainer to be used by a subsequent container.