### PR TITLE
Optionally enable profiling

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -49,6 +49,7 @@ func defineFlags(rootCmd *cobra.Command) {
 	rootCmd.Flags().String("socket-path", "", "The path to the socket to listen at")
 	rootCmd.Flags().Int("socket-uid", 0, "The user owner of the status HTTP socket")
 	rootCmd.Flags().Int("socket-gid", 0, "The group owner of the status HTTP socket")
+	rootCmd.Flags().Bool("enable-profiling", false, "whether to enable or not profiling endpoints in the status server.")
 }
 
 func parseFlags(rootCmd *cobra.Command) (*daemon.SelinuxdOptions, error) {
@@ -68,6 +69,11 @@ func parseFlags(rootCmd *cobra.Command) (*daemon.SelinuxdOptions, error) {
 	config.Path, err = rootCmd.Flags().GetString("socket-path")
 	if err != nil {
 		return nil, fmt.Errorf("failed getting socket-path flag: %w", err)
+	}
+
+	config.EnableProfiling, err = rootCmd.Flags().GetBool("enable-profiling")
+	if err != nil {
+		return nil, fmt.Errorf("failed getting enable-profiling flag: %w", err)
 	}
 
 	return &config, nil

--- a/pkg/daemon/status_server.go
+++ b/pkg/daemon/status_server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"os"
 
 	"github.com/JAORMX/selinuxd/pkg/semodule"
@@ -17,9 +18,10 @@ const (
 )
 
 type StatusServerConfig struct {
-	Path string
-	UID  int
-	GID  int
+	Path            string
+	UID             int
+	GID             int
+	EnableProfiling bool
 }
 
 func createSocket(path string, uid, gid int) (net.Listener, error) {
@@ -81,6 +83,13 @@ func serveState(config StatusServerConfig, sh semodule.Handler, logger logr.Logg
 	}
 
 	mux.HandleFunc("/policies/", policiesHandler)
+	if config.EnableProfiling {
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
 	server := &http.Server{
 		Handler: mux,
 	}


### PR DESCRIPTION
This adds a `--enable-profiling` flag to the daemon which can enable
some profiling endpoints in the status server similar to the defaults
that pprof gives.