### PR TITLE
semanage: Fix commit error wrapping

### DIFF
--- a/pkg/semodule/semanage/semanage.go
+++ b/pkg/semodule/semanage/semanage.go
@@ -52,7 +52,7 @@ func NewErrCannotInstallModule(mName string) error {
 }
 
 func NewErrCommit(origErrVal int) error {
-	return fmt.Errorf("%w - error code: %d", ErrCannotInstallModule, origErrVal)
+	return fmt.Errorf("%w - error code: %d", ErrCommit, origErrVal)
 }
 
 //export LogWrapper


### PR DESCRIPTION
The semanage interface has a wrapped error for when commits fail. We
were wrapping the wrong error, instead we should wrap the "commit" one
to be able to correctly identify it if needed.