### PR TITLE
Enhance installation speed (theoretically)

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -109,7 +109,7 @@ func daemonCmdFunc(rootCmd *cobra.Command, _ []string) {
 	}
 	defer sh.Close()
 
-	go daemon.Daemon(options, defaultModulePath, sh, done, logger)
+	go daemon.Daemon(options, defaultModulePath, sh, nil, done, logger)
 
 	<-exitSignal
 	logger.Info("Exit signal received")

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -103,7 +103,7 @@ func daemonCmdFunc(rootCmd *cobra.Command, _ []string) {
 	done := make(chan bool)
 	signal.Notify(exitSignal, syscall.SIGINT, syscall.SIGTERM)
 
-	sh, err := semanage.NewSemanageHandler(logger)
+	sh, err := semanage.NewSemanageHandler(true, logger)
 	if err != nil {
 		logger.Error(err, "Creating semanage handler")
 	}

--- a/pkg/daemon/action.go
+++ b/pkg/daemon/action.go
@@ -46,7 +46,12 @@ func (pi *policyInstall) do(modulePath string, sh semodule.Handler, ds datastore
 		msg = installErr.Error()
 	}
 
-	puterr := ds.PutStatus(policyName, status, msg)
+	ps := datastore.PolicyStatus{
+		Policy:  policyName,
+		Status:  status,
+		Message: msg,
+	}
+	puterr := ds.Put(ps)
 	if puterr != nil {
 		return "", fmt.Errorf("failed persisting status in datastore: %w", puterr)
 	}

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -14,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/JAORMX/selinuxd/pkg/datastore"
 	"github.com/JAORMX/selinuxd/pkg/semodule/test"
 	backoff "github.com/cenkalti/backoff/v4"
 	"github.com/go-logr/zapr"
@@ -26,18 +26,23 @@ const (
 )
 
 var (
-	errModuleNotInstalled = fmt.Errorf("the module wasn't installed")
-	errModuleInstalled    = fmt.Errorf("the module was installed when it shouldn't")
+	errModuleNotInstalled    = fmt.Errorf("the module wasn't installed")
+	errModuleInstalled       = fmt.Errorf("the module was installed when it shouldn't")
+	errInstallNotPerfomedYet = fmt.Errorf("install action not performed yet")
 )
 
-func installPolicy(module, path string, t *testing.T) io.Closer {
+func getPolicyPath(module, path string) string {
 	moduleFileName := module + ".cil"
-	modPath := filepath.Join(path, moduleFileName)
-	f, err := os.Create(modPath)
+	return filepath.Join(path, moduleFileName)
+}
+
+func installPolicy(module, path string, t *testing.T) {
+	modPath := getPolicyPath(module, path)
+	message := []byte("Hello, Gophers!")
+	err := ioutil.WriteFile(modPath, message, 0600)
 	if err != nil {
-		t.Fatalf("Couldn't open module file %s: %s", modPath, err)
+		t.Fatal(err)
 	}
-	return f
 }
 
 func removePolicy(module, path string, t *testing.T) {
@@ -104,11 +109,17 @@ func TestDaemon(t *testing.T) {
 	defer cancel()
 
 	sh := test.NewSEModuleTestHandler()
-	go Daemon(&config, moddir, sh, done, zapr.NewLogger(logger))
 
-	t.Run("Module should install a policy", func(t *testing.T) {
-		f := installPolicy(moduleName, moddir, t)
-		defer f.Close()
+	ds, err := datastore.NewTestCountedDS(config.StatusDBPath)
+	if err != nil {
+		t.Fatalf("Unable to get R/W datastore: %s", err)
+	}
+	defer ds.Close()
+
+	go Daemon(&config, moddir, sh, ds, done, zapr.NewLogger(logger))
+
+	t.Run("Should install a policy", func(t *testing.T) {
+		installPolicy(moduleName, moddir, t)
 
 		// Module has to be installed... eventually
 		err := backoff.Retry(func() error {
@@ -119,6 +130,39 @@ func TestDaemon(t *testing.T) {
 		}, backoff.WithMaxRetries(backoff.NewConstantBackOff(defaultPollBackOff), 5))
 		if err != nil {
 			t.Fatalf("%s", err)
+		}
+	})
+
+	t.Run("Should skip policy installation if it's already installed", func(t *testing.T) {
+		initPolicyGets := ds.GetCalls()
+		initPolicyPuts := ds.PutCalls()
+		time.Sleep(1 * time.Second)
+		// Overwritting a policy with the same contents should not
+		// trigger another PUT
+		installPolicy(moduleName, moddir, t)
+
+		var currentGetCalls, currentPutCalls int32
+
+		// Module has to be installed... eventually
+		err := backoff.Retry(func() error {
+			// "touching" the policy will trigger an inotify
+			// event which will attempt to install it again.
+			// The action interface will "get" the policy
+			// and compare the checksum
+			currentGetCalls = ds.GetCalls()
+			currentPutCalls = ds.PutCalls()
+			if initPolicyGets == currentGetCalls {
+				return errInstallNotPerfomedYet
+			}
+			return nil
+		}, backoff.WithMaxRetries(backoff.NewConstantBackOff(defaultPollBackOff), 5))
+		if err != nil {
+			t.Fatalf("%s. Got GET calls %d - Started with %d", err, currentGetCalls, initPolicyGets)
+		}
+
+		if currentPutCalls != initPolicyPuts {
+			t.Fatalf("The policy was updated unexpectedly. Got put calls: %d - Expected: %d",
+				currentGetCalls, initPolicyPuts)
 		}
 	})
 

--- a/pkg/daemon/status_server.go
+++ b/pkg/daemon/status_server.go
@@ -118,7 +118,7 @@ func (ss *statusServer) listPoliciesHandler(w http.ResponseWriter, r *http.Reque
 func (ss *statusServer) getPolicyStatusHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	policy := vars["policy"]
-	status, msg, err := ss.ds.GetStatus(policy)
+	status, err := ss.ds.Get(policy)
 	if errors.Is(err, datastore.ErrPolicyNotFound) {
 		http.Error(w, "couldn't find requested policy", http.StatusNotFound)
 		return
@@ -128,11 +128,7 @@ func (ss *statusServer) getPolicyStatusHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	output := map[string]string{
-		"status": string(status),
-		"msg":    msg,
-	}
-	err = json.NewEncoder(w).Encode(output)
+	err = json.NewEncoder(w).Encode(status)
 	if err != nil {
 		ss.l.Error(err, "error writing status response")
 		http.Error(w, "Cannot get status", http.StatusInternalServerError)

--- a/pkg/datastore/bbolt.go
+++ b/pkg/datastore/bbolt.go
@@ -51,7 +51,7 @@ func (ds *bboltDataStore) GetReadOnly() ReadOnlyDataStore {
 	return ds
 }
 
-func (ds *bboltDataStore) PutStatus(policy string, status StatusType, msg string) error {
+func (ds *bboltDataStore) Put(status PolicyStatus) error {
 	if ds.db == nil {
 		return ErrDataStoreNotInitialized
 	}
@@ -60,15 +60,15 @@ func (ds *bboltDataStore) PutStatus(policy string, status StatusType, msg string
 		if root == nil {
 			return ErrDataStoreNotInitialized
 		}
-		bkt, err := root.CreateBucketIfNotExists([]byte(policy))
+		bkt, err := root.CreateBucketIfNotExists([]byte(status.Policy))
 		if err != nil {
 			return fmt.Errorf("couldn't create policy entry: %w", err)
 		}
-		err = bkt.Put([]byte("status"), []byte(status))
+		err = bkt.Put([]byte("status"), []byte(status.Status))
 		if err != nil {
 			return fmt.Errorf("couldn't persist policy status: %w", err)
 		}
-		err = bkt.Put([]byte("msg"), []byte(msg))
+		err = bkt.Put([]byte("msg"), []byte(status.Message))
 		if err != nil {
 			return fmt.Errorf("couldn't persist policy status message: %w", err)
 		}
@@ -76,10 +76,10 @@ func (ds *bboltDataStore) PutStatus(policy string, status StatusType, msg string
 	})
 }
 
-func (ds *bboltDataStore) GetStatus(policy string) (StatusType, string, error) {
+func (ds *bboltDataStore) Get(policy string) (PolicyStatus, error) {
 	var status, msg []byte
 	if ds.db == nil {
-		return "", "", ErrDataStoreNotInitialized
+		return PolicyStatus{}, ErrDataStoreNotInitialized
 	}
 	err := ds.db.View(func(tx *bolt.Tx) error {
 		root := tx.Bucket(ds.root)
@@ -95,10 +95,14 @@ func (ds *bboltDataStore) GetStatus(policy string) (StatusType, string, error) {
 		return nil
 	})
 	if err != nil {
-		return "", "", fmt.Errorf("couldn't get policy status: %w", err)
+		return PolicyStatus{}, fmt.Errorf("couldn't get policy status: %w", err)
 	}
 
-	return StatusType(status), string(msg), nil
+	return PolicyStatus{
+		Policy:  policy,
+		Status:  StatusType(status),
+		Message: string(msg),
+	}, nil
 }
 
 func (ds *bboltDataStore) List() ([]string, error) {

--- a/pkg/datastore/bbolt.go
+++ b/pkg/datastore/bbolt.go
@@ -72,12 +72,16 @@ func (ds *bboltDataStore) Put(status PolicyStatus) error {
 		if err != nil {
 			return fmt.Errorf("couldn't persist policy status message: %w", err)
 		}
+		err = bkt.Put([]byte("checksum"), status.Checksum)
+		if err != nil {
+			return fmt.Errorf("couldn't persist policy status message: %w", err)
+		}
 		return nil
 	})
 }
 
 func (ds *bboltDataStore) Get(policy string) (PolicyStatus, error) {
-	var status, msg []byte
+	var status, msg, cs []byte
 	if ds.db == nil {
 		return PolicyStatus{}, ErrDataStoreNotInitialized
 	}
@@ -92,6 +96,7 @@ func (ds *bboltDataStore) Get(policy string) (PolicyStatus, error) {
 		}
 		status = b.Get([]byte("status"))
 		msg = b.Get([]byte("msg"))
+		cs = b.Get([]byte("checksum"))
 		return nil
 	})
 	if err != nil {
@@ -99,9 +104,10 @@ func (ds *bboltDataStore) Get(policy string) (PolicyStatus, error) {
 	}
 
 	return PolicyStatus{
-		Policy:  policy,
-		Status:  StatusType(status),
-		Message: string(msg),
+		Policy:   policy,
+		Status:   StatusType(status),
+		Message:  string(msg),
+		Checksum: cs,
 	}, nil
 }
 

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -20,13 +20,13 @@ var (
 
 type ReadOnlyDataStore interface {
 	Close() error
-	GetStatus(policy string) (StatusType, string, error)
+	Get(policy string) (PolicyStatus, error)
 	List() ([]string, error)
 }
 
 type DataStore interface {
 	ReadOnlyDataStore
-	PutStatus(policy string, status StatusType, msg string) error
+	Put(status PolicyStatus) error
 	Remove(policy string) error
 	GetReadOnly() ReadOnlyDataStore
 }

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -66,12 +66,11 @@ func TestDataStore(t *testing.T) {
 }
 
 func TestStatusProbe(t *testing.T) {
-	type Args struct {
-		policy string
-		status StatusType
-		msg    string
+	status := PolicyStatus{
+		Status:  InstalledStatus,
+		Policy:  "my-policy",
+		Message: "all is good",
 	}
-	args := Args{"my-policy", "installed", "all is good"}
 
 	path, filecleanup := getNewStorePath(t)
 	defer filecleanup()
@@ -79,30 +78,29 @@ func TestStatusProbe(t *testing.T) {
 	defer dscleanup()
 
 	// We should be able to write a status correctly
-	if err := ds.PutStatus(args.policy, args.status, args.msg); err != nil {
+	if err := ds.Put(status); err != nil {
 		t.Errorf("DataStore.PutStatus() error = %v", err)
 	}
 
 	// We should be able to read a status correctly
-	status, msg, err := ds.GetStatus(args.policy)
+	rs, err := ds.Get(status.Policy)
 	if err != nil {
 		t.Errorf("DataStore.GetStatus() error = %v", err)
 	}
-	if args.status != status {
-		t.Errorf("DataStore.GetStatus() status didn't match. got: %s, expected: %s", status, args.status)
+	if status.Status != rs.Status {
+		t.Errorf("DataStore.GetStatus() status didn't match. got: %s, expected: %s", rs.Status, status.Status)
 	}
-	if args.msg != msg {
-		t.Errorf("DataStore.GetStatus() msg didn't match. got: %s, expected: %s", msg, args.msg)
+	if status.Message != rs.Message {
+		t.Errorf("DataStore.GetStatus() msg didn't match. got: %s, expected: %s", rs.Message, status.Message)
 	}
 }
 
 func TestStatusProbeReadOnly(t *testing.T) {
-	type Args struct {
-		policy string
-		status StatusType
-		msg    string
+	status := PolicyStatus{
+		Status:  InstalledStatus,
+		Policy:  "my-policy",
+		Message: "all is good",
 	}
-	args := Args{"my-policy", "installed", "all is good"}
 
 	path, filecleanup := getNewStorePath(t)
 	defer filecleanup()
@@ -111,33 +109,28 @@ func TestStatusProbeReadOnly(t *testing.T) {
 	rods := ds.GetReadOnly()
 
 	// We should be able to write a status correctly
-	if err := ds.PutStatus(args.policy, args.status, args.msg); err != nil {
+	if err := ds.Put(status); err != nil {
 		t.Errorf("DataStore.PutStatus() error = %v", err)
 	}
 
 	// We should be able to read a status correctly with the read-only interface
-	status, msg, err := rods.GetStatus(args.policy)
+	rs, err := rods.Get(status.Policy)
 	if err != nil {
 		t.Errorf("DataStore.GetStatus() error = %v", err)
 	}
-	if args.status != status {
-		t.Errorf("DataStore.GetStatus() status didn't match. got: %s, expected: %s", status, args.status)
+	if status.Status != rs.Status {
+		t.Errorf("DataStore.GetStatus() status didn't match. got: %s, expected: %s", rs.Status, status.Status)
 	}
-	if args.msg != msg {
-		t.Errorf("DataStore.GetStatus() msg didn't match. got: %s, expected: %s", msg, args.msg)
+	if status.Message != rs.Message {
+		t.Errorf("DataStore.GetStatus() msg didn't match. got: %s, expected: %s", rs.Message, status.Message)
 	}
 }
 
 func TestListPolicies(t *testing.T) {
-	type Args struct {
-		policy string
-		status StatusType
-		msg    string
-	}
-	argsList := []Args{
-		{"my-policy-1", "installed", "all is good"},
-		{"my-policy-2", "installed", "all is good"},
-		{"my-policy-3", "installed", "all is good"},
+	policyList := []PolicyStatus{
+		{Policy: "my-policy-1", Status: InstalledStatus, Message: "all is good"},
+		{Policy: "my-policy-2", Status: InstalledStatus, Message: "all is good"},
+		{Policy: "my-policy-3", Status: InstalledStatus, Message: "all is good"},
 	}
 
 	path, filecleanup := getNewStorePath(t)
@@ -145,9 +138,9 @@ func TestListPolicies(t *testing.T) {
 	ds, dscleanup := getNewStore(path, t)
 	defer dscleanup()
 
-	for _, args := range argsList {
+	for _, policy := range policyList {
 		// We should be able to write a status correctly
-		if err := ds.PutStatus(args.policy, args.status, args.msg); err != nil {
+		if err := ds.Put(policy); err != nil {
 			t.Errorf("DataStore.PutStatus() error = %v", err)
 		}
 	}
@@ -156,19 +149,18 @@ func TestListPolicies(t *testing.T) {
 	if err != nil {
 		t.Errorf("DataStore.List() error = %v", err)
 	}
-	if len(policies) != len(argsList) {
+	if len(policies) != len(policyList) {
 		t.Errorf("DataStore.List() didn't output the expected number of policies. Got %d, Expected %d",
-			len(policies), len(argsList))
+			len(policies), len(policyList))
 	}
 }
 
 func TestRemovePolicy(t *testing.T) {
-	type Args struct {
-		policy string
-		status StatusType
-		msg    string
+	status := PolicyStatus{
+		Status:  InstalledStatus,
+		Policy:  "my-policy",
+		Message: "all is good",
 	}
-	args := Args{"my-policy-1", "installed", "all is good"}
 
 	path, filecleanup := getNewStorePath(t)
 	defer filecleanup()
@@ -176,7 +168,7 @@ func TestRemovePolicy(t *testing.T) {
 	defer dscleanup()
 
 	// We should be able to write a status correctly
-	if err := ds.PutStatus(args.policy, args.status, args.msg); err != nil {
+	if err := ds.Put(status); err != nil {
 		t.Errorf("DataStore.PutStatus() error = %v", err)
 	}
 
@@ -190,7 +182,7 @@ func TestRemovePolicy(t *testing.T) {
 	}
 
 	// Remove the policy
-	if err := ds.Remove(args.policy); err != nil {
+	if err := ds.Remove(status.Policy); err != nil {
 		t.Errorf("DataStore.Remove() error = %v", err)
 	}
 

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -67,9 +67,10 @@ func TestDataStore(t *testing.T) {
 
 func TestStatusProbe(t *testing.T) {
 	status := PolicyStatus{
-		Status:  InstalledStatus,
-		Policy:  "my-policy",
-		Message: "all is good",
+		Status:   InstalledStatus,
+		Policy:   "my-policy",
+		Message:  "all is good",
+		Checksum: []byte("123"),
 	}
 
 	path, filecleanup := getNewStorePath(t)
@@ -97,9 +98,10 @@ func TestStatusProbe(t *testing.T) {
 
 func TestStatusProbeReadOnly(t *testing.T) {
 	status := PolicyStatus{
-		Status:  InstalledStatus,
-		Policy:  "my-policy",
-		Message: "all is good",
+		Status:   InstalledStatus,
+		Policy:   "my-policy",
+		Message:  "all is good",
+		Checksum: []byte("123"),
 	}
 
 	path, filecleanup := getNewStorePath(t)

--- a/pkg/datastore/policystatus.go
+++ b/pkg/datastore/policystatus.go
@@ -3,7 +3,8 @@ package datastore
 // PolicyStatus defines the status of a specific
 // policy in the datastore.
 type PolicyStatus struct {
-	Policy  string     `json:"-"`
-	Status  StatusType `json:"status"`
-	Message string     `json:"msg"`
+	Policy   string     `json:"-"`
+	Status   StatusType `json:"status"`
+	Message  string     `json:"msg"`
+	Checksum []byte     `json:"-"`
 }

--- a/pkg/datastore/policystatus.go
+++ b/pkg/datastore/policystatus.go
@@ -1,0 +1,9 @@
+package datastore
+
+// PolicyStatus defines the status of a specific
+// policy in the datastore.
+type PolicyStatus struct {
+	Policy  string     `json:"-"`
+	Status  StatusType `json:"status"`
+	Message string     `json:"msg"`
+}

--- a/pkg/datastore/test.go
+++ b/pkg/datastore/test.go
@@ -1,0 +1,59 @@
+package datastore
+
+import "sync/atomic"
+
+// TestCountedDS a wrapper over the bbolt datastore
+// that contains counters which are meant to aid
+// in testing
+type TestCountedDS struct {
+	ds         DataStore
+	getCounter int32
+	putCounter int32
+}
+
+func NewTestCountedDS(path string) (*TestCountedDS, error) {
+	ds, err := newBboltDS(path)
+	if err != nil {
+		return nil, err
+	}
+	tcds := &TestCountedDS{
+		ds:         ds,
+		getCounter: 0,
+		putCounter: 0,
+	}
+	return tcds, nil
+}
+
+func (tcds *TestCountedDS) Close() error {
+	return tcds.ds.Close()
+}
+
+func (tcds *TestCountedDS) Get(policy string) (PolicyStatus, error) {
+	atomic.AddInt32(&tcds.getCounter, 1)
+	return tcds.ds.Get(policy)
+}
+
+func (tcds *TestCountedDS) GetCalls() int32 {
+	return atomic.LoadInt32(&tcds.getCounter)
+}
+
+func (tcds *TestCountedDS) List() ([]string, error) {
+	return tcds.ds.List()
+}
+
+func (tcds *TestCountedDS) Put(status PolicyStatus) error {
+	atomic.AddInt32(&tcds.putCounter, 1)
+	return tcds.ds.Put(status)
+}
+
+func (tcds *TestCountedDS) PutCalls() int32 {
+	return atomic.LoadInt32(&tcds.putCounter)
+}
+
+func (tcds *TestCountedDS) Remove(policy string) error {
+	return tcds.ds.Remove(policy)
+}
+
+func (tcds *TestCountedDS) GetReadOnly() ReadOnlyDataStore {
+	return tcds.ds.GetReadOnly()
+}

--- a/pkg/semodule/interface.go
+++ b/pkg/semodule/interface.go
@@ -3,8 +3,10 @@ package semodule
 // Handler implements an interface to interact
 // with SELinux modules.
 type Handler interface {
+	SetAutoCommit(bool)
 	Install(string) error
 	List() ([]string, error)
 	Remove(string) error
+	Commit() error
 	Close() error
 }

--- a/pkg/semodule/test/testhandler.go
+++ b/pkg/semodule/test/testhandler.go
@@ -19,6 +19,9 @@ func NewSEModuleTestHandler() *SEModuleTestHandler {
 	return &SEModuleTestHandler{}
 }
 
+func (smt *SEModuleTestHandler) SetAutoCommit(bool) {
+}
+
 func (smt *SEModuleTestHandler) Install(modulePath string) error {
 	baseFile, err := utils.GetCleanBase(modulePath)
 	if err != nil {
@@ -71,5 +74,9 @@ func (smt *SEModuleTestHandler) Remove(modToRemove string) error {
 }
 
 func (smt *SEModuleTestHandler) Close() error {
+	return nil
+}
+
+func (smt *SEModuleTestHandler) Commit() error {
 	return nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,8 +1,11 @@
 package utils
 
 import (
+	"crypto/sha512"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 )
 
@@ -45,4 +48,20 @@ func PolicyNameFromPath(path string) (string, error) {
 	}
 	policy := GetFileWithoutExtension(baseFile)
 	return policy, nil
+}
+
+// Checksum returns a checksum for a file on a given path
+func Checksum(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to calculate checksum: %w", err)
+	}
+	defer f.Close()
+
+	h := sha512.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return nil, fmt.Errorf("unable to calculate checksum: %w", err)
+	}
+
+	return h.Sum(nil), nil
 }


### PR DESCRIPTION
This exposes the Commit operation in the SeModule Handler code. It also
exposes the auto commit setting. What this means is that now we're able
to tell the library that we want to gather all modules and try to
install them all as part of the same transaction as opposed to doing it
per policy.

This is then used in the oneshot command, where the command will try to
do a single transaction to install all the policies, and if that fails
it'll go policy per policy installing them. This is meant to speed up
setting up initial policies.

Furthermore, this implements checksumming of all incoming policies.
The aforementioned checksum is stored in the datastore and checked on
every time we install a policy. With this, we are able to skip installing a
policy if it was previously installed and the checksum did not change.

Finally, with the addition of that checksum, in order to not add each policy
status part to the datastore functions, this now formalizes the policy status
definition into one struct. This struct is now even used to serialize the status
into JSON.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>