### PR TITLE
Install udica into the selinux container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ LABEL name="selinuxd" \
 # TODO(jaosorior): Remove once we use static linking
 RUN dnf install -y --disableplugin=subscription-manager \
     --enablerepo=powertools \
+    udica \
     policycoreutils
 
 COPY --from=build /work/bin/selinuxdctl /usr/bin/


### PR DESCRIPTION
This way consumers of udica can take the base policies into use.