### PR TITLE
Enable fedora and centos container images builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ IMAGE_TAG=latest
 IMAGE_REF=$(IMAGE_NAME):$(IMAGE_TAG)
 
 IMAGE_REPO?=quay.io/jaosorior/$(IMAGE_REF)
+CENTOS_IMAGE_REPO?=quay.io/jaosorior/$(IMAGE_NAME)-centos:$(IMAGE_TAG)
+FEDORA_IMAGE_REPO?=quay.io/jaosorior/$(IMAGE_NAME)-fedora:$(IMAGE_TAG)
 
 # Targets
 
@@ -79,8 +81,19 @@ $(GOPATH)/bin/golangci-lint:
 	GOLANGCI_LINT_CACHE=/tmp/golangci-cache $(GOPATH)/bin/golangci-lint linters
 
 .PHONY: image
-image:
-	$(CONTAINTER_RUNTIME) build -t $(IMAGE_REPO) .
+image: default-image centos-image fedora-image
+
+.PHONY: default-image
+default-image:
+	$(CONTAINTER_RUNTIME) build -f images/Dockerfile.centos -t $(IMAGE_REPO) .
+
+.PHONY: centos-image
+centos-image:
+	$(CONTAINTER_RUNTIME) build -f images/Dockerfile.centos -t $(CENTOS_IMAGE_REPO) .
+
+.PHONY: fedora-image
+fedora-image:
+	$(CONTAINTER_RUNTIME) build -f images/Dockerfile.fedora -t $(FEDORA_IMAGE_REPO) .
 
 .PHONY: push
 push:

--- a/images/Dockerfile.centos
+++ b/images/Dockerfile.centos
@@ -1,0 +1,49 @@
+# Copyright © 2020 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM registry.centos.org/centos:8 AS build
+USER root
+WORKDIR /work
+
+# Speed up build by leveraging docker layer caching
+COPY go.mod go.sum vendor/ ./
+RUN mkdir -p bin
+
+RUN dnf install -y --disableplugin=subscription-manager \
+    --enablerepo=powertools \
+    golang make libsemanage-devel
+
+ADD . /work
+
+RUN make
+
+FROM registry.centos.org/centos:8
+# TODO(jaosorior): Switch to UBI once we use static linking
+#FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+# TODO(jaosorior): See if we can run this without root
+USER root
+
+LABEL name="selinuxd" \
+      description="selinuxd is a daemon that listens for files in /etc/selinux.d/ and installs the relevant policies."
+
+# TODO(jaosorior): Remove once we use static linking
+RUN dnf install -y --disableplugin=subscription-manager \
+    --enablerepo=powertools \
+    udica \
+    policycoreutils
+
+COPY --from=build /work/bin/selinuxdctl /usr/bin/
+
+ENTRYPOINT ["/usr/bin/selinuxdctl"]

--- a/images/Dockerfile.fedora
+++ b/images/Dockerfile.fedora
@@ -1,0 +1,42 @@
+# Copyright © 2020 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM registry.fedoraproject.org/fedora-minimal:33 AS build
+USER root
+WORKDIR /work
+
+# Speed up build by leveraging docker layer caching
+COPY go.mod go.sum vendor/ ./
+RUN mkdir -p bin
+
+RUN microdnf install -y golang make libsemanage-devel
+
+ADD . /work
+
+RUN make
+
+FROM registry.fedoraproject.org/fedora-minimal:33
+
+# TODO(jaosorior): See if we can run this without root
+USER root
+
+LABEL name="selinuxd" \
+      description="selinuxd is a daemon that listens for files in /etc/selinux.d/ and installs the relevant policies."
+
+# TODO(jaosorior): Remove once we use static linking
+RUN microdnf install -y udica policycoreutils
+
+COPY --from=build /work/bin/selinuxdctl /usr/bin/
+
+ENTRYPOINT ["/usr/bin/selinuxdctl"]


### PR DESCRIPTION
Since libsemanage isn't compatible between fedora and centos (which also
encompasses RHCOS and RHEL), we need to have separate images for
selinuxd to work on these distros.

I will eventually remove the top-level Dockerfile in favor of the ones
in the images directory.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>