### PR TITLE
Switch to only triggering github actions on "push"

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -1,6 +1,6 @@
 name: build-and-test
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build-selinuxd:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,6 +1,6 @@
 name: verify
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build-selinuxd:


### PR DESCRIPTION
Doing so for both push and pull_request was triggering the actions twice
per PR. This was not what we wanted. Instead lets only trigger on push,
which should also work on PRs and should retrigger once a new push is
done to any branch.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>