### PR TITLE
Add e2e test setup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,44 @@
+name: e2e
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  fedora-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make fedora-image
+      - run: podman save -o image.tar quay.io/jaosorior/selinuxd-fedora:latest
+      - uses: actions/upload-artifact@v2
+        with:
+          name: fedora-image-tar
+          path: image.tar
+
+  fedora-e2e:
+    needs: fedora-image
+    runs-on: macos-10.15
+    timeout-minutes: 80
+    env:
+      RUN: ./hack/ci/run.sh
+      IMG: quay.io/jaosorior/selinuxd-fedora:latest
+      CONTAINER_NAME: selinuxd
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: fedora-image-tar
+          path: .
+      - name: Boot Virtual Machine
+        run: make vagrant-up
+      - name: Run selinuxd
+        run: $RUN hack/ci/daemon.sh
+      - name: Run E2E tests
+        run: $RUN hack/ci/e2e.sh
+      - name: Get logs
+        run: $RUN hack/ci/logs.sh
+      - uses: actions/upload-artifact@v2
+        with:
+          name: e2e-fedora-logs
+          path: ${{ env.CONTAINER_NAME }}.logs

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ $(BIN): $(BINDIR) $(SRC) pkg/semodule/semanage/callbacks.c
 test:
 	go test -race github.com/JAORMX/selinuxd/...
 
+.PHONY: e2e
+e2e:
+	/bin/true
+
 .PHONY: run
 run: $(BIN) $(POLICYDIR)
 	sudo $(BIN) daemon
@@ -98,3 +102,12 @@ fedora-image:
 .PHONY: push
 push:
 	$(CONTAINTER_RUNTIME) push $(IMAGE_REPO)
+
+.PHONY: vagrant-up
+vagrant-up: ## Boot the vagrant based test VM
+	if [ ! -f image.tar ]; then \
+		make image IMAGE=$(IMAGE) && \
+		$(CONTAINER_RUNTIME) save -o image.tar $(IMAGE); \
+	fi
+	ln -sf hack/ci/Vagrantfile .
+	vagrant up

--- a/hack/ci/Vagrantfile
+++ b/hack/ci/Vagrantfile
@@ -1,0 +1,38 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrant box for testing
+Vagrant.configure("2") do |config|
+  config.vm.box = "fedora/33-cloud-base"
+  memory = 6144
+  cpus = 4
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = memory
+    v.cpus = cpus
+  end
+
+  config.vm.provider :libvirt do |v|
+    v.memory = memory
+    v.cpus = cpus
+  end
+
+  config.vm.provision "install-dependencies", type: "shell", run: "once" do |sh|
+    sh.inline = <<~SHELL
+    whoami
+      set -euxo pipefail
+      dnf install -y \
+        make \
+        oci-seccomp-bpf-hook \
+        podman
+    SHELL
+  end
+
+  config.vm.provision "load-test-image", type: "shell", run: "once" do |sh|
+    sh.inline = <<~SHELL
+      set -euxo pipefail
+      sudo podman load -i /vagrant/image.tar
+    SHELL
+  end
+
+end

--- a/hack/ci/daemon.sh
+++ b/hack/ci/daemon.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+IMG="${IMG:-quay.io/jaosorior/selinuxd-fedora:latest}"
+CONTAINER_NAME="${CONTAINER_NAME:-selinuxd}"
+
+mkdir -p /etc/selinux.d
+
+# Initialize base policies
+podman run \
+    --name policy-copy \
+    --privileged \
+    -v /etc/selinux.d:/etc/selinux.d \
+    --entrypoint /bin/bash \
+    $IMG -c 'cp /usr/share/selinuxd/templates/* /etc/selinux.d/'
+
+# run daemon
+podman run \
+    --name "$CONTAINER_NAME" \
+    -d \
+    --privileged \
+    -v /sys/fs/selinux:/sys/fs/selinux \
+    -v /var/lib/selinux:/var/lib/selinux \
+    -v /etc/selinux.d:/etc/selinux.d \
+    $IMG daemon

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+make e2e

--- a/hack/ci/logs.sh
+++ b/hack/ci/logs.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+CONTAINER_NAME="${CONTAINER_NAME:-selinuxd}"
+
+# NOTE(jaosorior): Added -t so we get readable timestamps.
+podman logs -t "$CONTAINER_NAME" > "$CONTAINER_NAME.logs"

--- a/hack/ci/run.sh
+++ b/hack/ci/run.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+exec vagrant ssh -- sudo "bash -c 'cd /vagrant && $*'"


### PR DESCRIPTION
This adds the basic setup to do e2e tests.

Note that e2e tests are still missing, but this gives us the ability to run them by:

* Adding an appropriate github actions workflow
* Adding a Vagrant configuration that sets up a fedora VM
* Running the daemon in a container
* fetching logs in the end of the run

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>