### PR TITLE
Add e2e test for erroneous policy

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -30,5 +30,24 @@ var _ = Describe("E2e", func() {
 				policyEventually(policy).Should(MatchRegexp(`status.*Installed`))
 			})
 		})
+
+		When("Installing a erroneous policy", func() {
+			var (
+				policy     = "badtestport"
+				policyPath = filepath.Join(selinuxdDir, fmt.Sprintf("%s.cil", policy))
+			)
+			BeforeEach(func() {
+				installPolicyFromReference("../data/badtestport.cil", policyPath)
+			})
+
+			AfterEach(func() {
+				removePolicyIfPossible(policyPath)
+			})
+
+			It("Reports an error status", func() {
+				By("Waiting for the policy to be installed")
+				policyEventually(policy).Should(MatchRegexp(`status.*Failed`))
+			})
+		})
 	})
 })


### PR DESCRIPTION
This test is meant to verify that selinuxd will report a Failed status
for an erroneous policy.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>