### PR TITLE
Use udica to generate selinux policy for selinuxd container

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,3 +42,9 @@ jobs:
         with:
           name: e2e-fedora-logs
           path: ${{ env.CONTAINER_NAME }}.logs
+      - name: Fetch selinux policy
+        run: $RUN cat selinuxd.cil > selinuxd.cil
+      - uses: actions/upload-artifact@v2
+        with:
+          name: selinux-policy
+          path: selinuxd.cil

--- a/hack/ci/Vagrantfile
+++ b/hack/ci/Vagrantfile
@@ -25,7 +25,8 @@ Vagrant.configure("2") do |config|
         make \
         golang \
         oci-seccomp-bpf-hook \
-        podman
+        podman \
+        udica
     SHELL
   end
 

--- a/hack/ci/daemon.sh
+++ b/hack/ci/daemon.sh
@@ -36,3 +36,6 @@ podman run \
     -v /var/lib/selinux:/var/lib/selinux \
     -v /etc/selinux.d:/etc/selinux.d \
     $IMG daemon
+
+# Should create selinuxd.cil
+podman inspect "$CONTAINER_NAME" | udica selinuxd


### PR DESCRIPTION
In order to lock down the selinux deployment, this uses Udica to
generate an appropriate policy. This is eventually uploaded as an
artifact as part of the CI run.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>