### PR TITLE
Automatically retry VM provisioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,4 +111,6 @@ vagrant-up: ## Boot the vagrant based test VM
 		$(CONTAINER_RUNTIME) save -o image.tar $(IMAGE); \
 	fi
 	ln -sf hack/ci/Vagrantfile .
-	vagrant up
+	# Retry in case provisioning failed because of some temporarily unavailable
+	# remote resource (like the VM image)
+	vagrant up || vagrant up || vagrant up


### PR DESCRIPTION
This allows us to get across manual CI retries if the download if the
image download has failed.

Props to @saschagrunert who originally authored this.

Co-Authored-By: Sascha Grunert <sgrunert@redhat.com>
Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>