### PR TITLE
Add sub-directory tracking

### DIFF
--- a/cmd/oneshot.go
+++ b/cmd/oneshot.go
@@ -62,7 +62,7 @@ func tryInstallAllPolicies(sh semodule.Handler, ds datastore.DataStore, logger l
 	policyops := make(chan daemon.PolicyAction)
 
 	go func() {
-		if err := daemon.InstallPoliciesInDir(defaultModulePath, policyops); err != nil {
+		if err := daemon.InstallPoliciesInDir(defaultModulePath, policyops, nil); err != nil {
 			logger.Error(err, "Installing policies in module directory")
 		}
 		close(policyops)

--- a/pkg/daemon/action.go
+++ b/pkg/daemon/action.go
@@ -34,12 +34,8 @@ func (pi *policyInstall) do(modulePath string, sh semodule.Handler, ds datastore
 	if err != nil {
 		return "", fmt.Errorf("installing policy: %w", err)
 	}
-	policyPath, err := utils.GetSafePath(modulePath, pi.path)
-	if err != nil {
-		return "", fmt.Errorf("failed getting a safe path for policy: %w", err)
-	}
 
-	cs, csErr := utils.Checksum(policyPath)
+	cs, csErr := utils.Checksum(pi.path)
 	if csErr != nil {
 		return "", fmt.Errorf("installing policy: %w", csErr)
 	}
@@ -53,7 +49,7 @@ func (pi *policyInstall) do(modulePath string, sh semodule.Handler, ds datastore
 		return "", fmt.Errorf("installing policy: couldn't access datastore: %w", getErr)
 	}
 
-	installErr := sh.Install(policyPath)
+	installErr := sh.Install(pi.path)
 	status := datastore.InstalledStatus
 	var msg string
 

--- a/pkg/daemon/dispatcher.go
+++ b/pkg/daemon/dispatcher.go
@@ -1,0 +1,43 @@
+package daemon
+
+import (
+	"os"
+
+	"gopkg.in/fsnotify.v1"
+)
+
+type fileOperationDispatch uint8
+
+const (
+	dispatchFileAddition fileOperationDispatch = iota
+	dispatchDirectoryAddition
+	dispatchRemoval
+	dispatchSymlink
+	dispatchUnkown
+)
+
+func dispatch(e fsnotify.Event) fileOperationDispatch {
+	// Since the file was removed, we can't stat
+	// the file or directory, so we have a generic removal
+	// dispatcher
+	if e.Op&fsnotify.Remove != 0 {
+		return dispatchRemoval
+	}
+
+	finfo, err := os.Stat(e.Name)
+	if err != nil {
+		return dispatchUnkown
+	}
+
+	if finfo.Mode()&os.ModeSymlink == os.ModeSymlink {
+		return dispatchSymlink
+	}
+
+	if e.Op&(fsnotify.Write|fsnotify.Create) != 0 {
+		if finfo.IsDir() {
+			return dispatchDirectoryAddition
+		}
+		return dispatchFileAddition
+	}
+	return dispatchUnkown
+}

--- a/pkg/semodule/test/testhandler.go
+++ b/pkg/semodule/test/testhandler.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"path/filepath"
 	"sync"
 
 	"github.com/JAORMX/selinuxd/pkg/semodule"
@@ -23,11 +24,7 @@ func (smt *SEModuleTestHandler) SetAutoCommit(bool) {
 }
 
 func (smt *SEModuleTestHandler) Install(modulePath string) error {
-	baseFile, err := utils.GetCleanBase(modulePath)
-	if err != nil {
-		// nolint:wrapcheck
-		return err
-	}
+	baseFile := filepath.Base(modulePath)
 	module := utils.GetFileWithoutExtension(baseFile)
 	// Only install module if it's not already there.
 	if smt.IsModuleInstalled(module) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -23,35 +23,11 @@ func GetFileWithoutExtension(filename string) string {
 	return filename[0 : len(filename)-len(extension)]
 }
 
-func GetCleanBase(path string) (string, error) {
-	// NOTE: don't trust the path even if it came from fsnotify
-	cleanPath := filepath.Clean(path)
-	if cleanPath == "" {
-		return "", NewErrInvalidPath(path)
-	}
-
-	// NOTE: Still not trusting that path. Let's just use the base
-	// and use our configured base path
-	return filepath.Base(cleanPath), nil
-}
-
-func GetSafePath(modulePath, path string) (string, error) {
-	policyFileBase, err := GetCleanBase(path)
-	if err != nil {
-		return "", err
-	}
-	policyPath := filepath.Join(modulePath, policyFileBase)
-	return policyPath, nil
-}
-
 func PolicyNameFromPath(path string) (string, error) {
 	if filepath.Ext(path) == "" {
 		return "", fmt.Errorf("ignoring: %w", ErrNoExtension)
 	}
-	baseFile, err := GetCleanBase(path)
-	if err != nil {
-		return "", fmt.Errorf("failed getting clean base name for policy: %w", err)
-	}
+	baseFile := filepath.Base(path)
 	policy := GetFileWithoutExtension(baseFile)
 	return policy, nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,7 +9,10 @@ import (
 	"path/filepath"
 )
 
-var ErrInvalidPath = errors.New("invalid path")
+var (
+	ErrInvalidPath = errors.New("invalid path")
+	ErrNoExtension = errors.New("file without extension")
+)
 
 func NewErrInvalidPath(path string) error {
 	return fmt.Errorf("%w: %s", ErrInvalidPath, path)
@@ -42,6 +45,9 @@ func GetSafePath(modulePath, path string) (string, error) {
 }
 
 func PolicyNameFromPath(path string) (string, error) {
+	if filepath.Ext(path) == "" {
+		return "", fmt.Errorf("ignoring: %w", ErrNoExtension)
+	}
 	baseFile, err := GetCleanBase(path)
 	if err != nil {
 		return "", fmt.Errorf("failed getting clean base name for policy: %w", err)

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -70,6 +71,32 @@ var _ = Describe("E2e", func() {
 				By("Updating policy to a valid one")
 				installPolicyFromReference("../data/testport.cil", policyPath)
 
+				By("Waiting for the policy to be installed")
+				policyEventually(policy).Should(MatchRegexp(`status.*Installed`))
+			})
+		})
+
+		When("Installing policy in sub-directory", func() {
+			var (
+				policy     = "subdirtestport"
+				subdirPath = filepath.Join(selinuxdDir, "my-subdir")
+				policyPath = filepath.Join(subdirPath, fmt.Sprintf("%s.cil", policy))
+			)
+			BeforeEach(func() {
+				By("Creating subdir")
+				mkdirErr := os.Mkdir(subdirPath, 0700)
+				Expect(mkdirErr).ToNot(HaveOccurred())
+				installPolicyFromReference("../data/testport.cil", policyPath)
+			})
+
+			AfterEach(func() {
+				removePolicyIfPossible(policyPath)
+				By("Deleting subdir")
+				rmdirErr := os.Remove(subdirPath)
+				Expect(rmdirErr).ToNot(HaveOccurred())
+			})
+
+			It("Reports an installed status", func() {
 				By("Waiting for the policy to be installed")
 				policyEventually(policy).Should(MatchRegexp(`status.*Installed`))
 			})


### PR DESCRIPTION
this ensures that selinuxd also takes sub-directories into account.

This ditches some previous code that would not trust the path... in this case
we have to trust the path from the fsnotify event as that will tell us the sub-directory.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>