### PR TITLE
Remove check for selinux policy diff

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,8 +62,3 @@ jobs:
         with:
           name: selinux-policy
           path: selinuxd.cil
-      - name: Verify generated selinux policy
-        run: diff selinuxd.cil security/selinuxd.cil
-      - name: Output seliinux policy instructions on failure
-        run: echo "The generated policy 'selinuxd.cil' differs from what's staged in 'security/selinuxd.cil'. Please update it."
-        if: ${{ failure() }}


### PR DESCRIPTION
We're currently not able to check this as Udica doesn't generate the
policy files in order.

Related-bug: https://github.com/containers/udica/issues/84
Closes https://github.com/JAORMX/selinuxd/issues/56