### PR TITLE
Add option to run secure deployment locally

### DIFF
--- a/hack/ci/e2e-local.sh
+++ b/hack/ci/e2e-local.sh
@@ -15,6 +15,8 @@
 
 set -euo pipefail
 
+export E2E_SECURE=${E2E_SECURE:-""}
+
 make fedora-image
 
 # Ensure image.tar isn't there
@@ -27,8 +29,14 @@ RUN=./hack/ci/run.sh
 echo "Spawning VM"
 make vagrant-up
 
-echo "Spawning selinuxd in VM"
-$RUN hack/ci/daemon-and-trace.sh
+
+if [ -z "$E2E_SECURE" ]; then
+    echo "Spawning selinuxd in VM with tracing"
+    $RUN hack/ci/daemon-and-trace.sh
+else
+    echo "Spawning selinuxd in VM with security features enabled"
+    $RUN hack/ci/daemon-secure.sh
+fi
 
 echo "Running e2e tests"
 $RUN hack/ci/e2e.sh


### PR DESCRIPTION
This adds the option to the e2e-local.sh script.

I'ts enabled via the `E2E_SECURE` option

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>