### PR TITLE
F-34: Use a newer container-selinux package

### DIFF
--- a/hack/ci/Vagrantfile
+++ b/hack/ci/Vagrantfile
@@ -31,6 +31,13 @@ Vagrant.configure("2") do |config|
     SHELL
   end
 
+  config.vm.provision "install the latest container-selinux", type: "shell", run: "once" do |sh|
+    sh.inline = <<~SHELL
+    dnf copr -y enable jhrozek/container-selinux-2-161
+    dnf upgrade -y container-selinux
+    SHELL
+  end
+
   config.vm.provision "load-test-image", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
       set -euxo pipefail

--- a/hack/ci/daemon-and-trace.sh
+++ b/hack/ci/daemon-and-trace.sh
@@ -19,10 +19,6 @@ source hack/ci/env.sh
 
 mkdir -p /etc/selinux.d
 
-sed -e '/RefuseManualStop/ s/^#*/#/' -i /usr/lib/systemd/system/auditd.service
-systemctl daemon-reload
-systemctl stop auditd
-
 # Initialize base policies
 podman run \
     --name policy-copy \


### PR DESCRIPTION
There was a new upstream release of container-selinux today which addresses
at least some of the issues we ran into. I think it is more systematic to use
it than disable auditd because disabling auditd is a horrible kludge. Also, the
container-selinux package will make it into F-34 soon (hopefully) and even newer
package would make the copr just obsolete even if we forgot to remove it later
(unlike removing auditd)