### PR TITLE
Use CentOS CIL policy

### DIFF
--- a/security/selinuxd.cil
+++ b/security/selinuxd.cil
@@ -1,7 +1,7 @@
 (block selinuxd
     (blockinherit container)
     (allow process process ( capability ( dac_override dac_read_search lease audit_write audit_control )))
- 
+
     (allow process default_context_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
     (allow process default_context_t ( fifo_file ( getattr read write append ioctl lock open )))
     (allow process default_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -14,7 +14,9 @@
     (allow process file_context_t ( fifo_file ( getattr read write append ioctl lock open )))
     (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
     (allow process file_context_t ( sock_file ( append getattr open read write )))
-    (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
+    (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
+    (allow process security_t ( security ( load_policy )))
+    (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
     (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
     (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
     (allow process selinux_config_t ( sock_file ( append getattr open read write )))


### PR DESCRIPTION
Instead of using the Fedora one which is not backwards compatible with
CentOS.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>